### PR TITLE
ヘッダーを作成した

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "start": "next start"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.35",
+    "@fortawesome/free-brands-svg-icons": "^5.15.3",
+    "@fortawesome/free-solid-svg-icons": "^5.15.3",
+    "@fortawesome/react-fontawesome": "^0.1.14",
     "next": "10.0.5",
     "react": "17.0.1",
     "react-dom": "17.0.1"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,17 +1,14 @@
+import React from 'react';
+
 import Image from 'next/image';
 import Link from 'next/link';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { ReactNode } from 'react';
 
-const Header = () => {
-  const headerMenu = [
-    {
-      name: 'Twitter',
-      url: 'https://twitter.com/kyutech_proken?lang=ja',
-    },
-    {
-      name: 'Blog',
-      url: 'https://twitter.com/kyutech_proken?lang=ja',
-    },
-  ];
+import { HeaderItems } from '../data/HeaderItems';
+import { ItemType } from '../types/headerItemType';
+import { socialLinks } from '../data/SocialLinks';
+import { socialLinksType } from '../types/socialLinksType';
 
   return (
     <>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,50 +10,56 @@ import { ItemType } from '../types/headerItemType';
 import { socialLinks } from '../data/SocialLinks';
 import { socialLinksType } from '../types/socialLinksType';
 
-  return (
-    <>
-      {/* Gradient area */}
-      <div className="top-0 h-8 bg-gradient-to-r from-green-400 to-blue-500">
-        <div className="sticky text-xl font-semibold text-white text-center">
-          Welcome to Proken HopePage!
-        </div>
-      </div>
-      {/* Header */}
-      <div className="sticky top-0 flex items-center justify-between bg-white p-2 border-b-2 border-gray-400 border-opacity-25">
-        {/* Logo and name */}
-        <div className="mr-6 cursor-pointer">
-          <Link href="/">
-            <div className="flex items-center">
-              <Image
-                className=""
-                src="/proken_logo.png"
-                alt="Proken logo"
-                width={64}
-                height={64}
-              />
-              <div className="px-2 font-extrabold text-2xl text-gray-600">
-                Proken 216
-              </div>
-            </div>
-          </Link>
-        </div>
+interface Props {
+  children: ReactNode;
+}
 
-        {/* Header menu */}
-        <div className="flex items-center justify-between">
-          {headerMenu.map((headerMenu) => (
-            <Link href={headerMenu.url}>
-              <div className="px-2 md:px-4">
-                <div
-                  className="font-bold text-xl text-gray-600"
-                  key={headerMenu.name}>
-                  {headerMenu.name}
-                </div>
-              </div>
+const Header: React.FC<Props> = ({ children }: Props) => {
+  return (
+    <div>
+      <div>
+        <div className="sticky top-0 h-16 flex justify-between items-center bg-white pt-10 md:p-10">
+          <div className="flex items-center font-bold text-2xl cursor-pointer">
+            <Link href="/">
+              <Image
+                src="/proken_logo.png"
+                alt="proken logo"
+                width={60}
+                height={60}
+              />
             </Link>
-          ))}
+            <Link href="/">
+              <div className="text-gray">プロ研216</div>
+            </Link>
+          </div>
+          <div className="flex justify-around items-center p-4 w-48">
+            {socialLinks.map((socialLink: socialLinksType) => (
+              <div className="flex">
+                <a
+                  href={socialLink.url}
+                  /*外部リンクを別タブで開く*/ target="_blank"
+                  /*target="_blank"の脆弱性回避*/ rel="noopener">
+                  <FontAwesomeIcon
+                    icon={socialLink.iconClass}
+                    size="2x"
+                    color={socialLink.color}
+                  />
+                </a>
+              </div>
+            ))}
+          </div>
         </div>
       </div>
-    </>
+      <div>
+        <div className="sticky top-0 h-16 flex justify-around items-center border-b-2 bg-white border-gray-200 px-4">
+          {HeaderItems.map((HeaderItem: ItemType) => (
+            <h1>{HeaderItem.title}</h1>
+          ))}
+          <div className="border-white"></div>
+        </div>
+        <div>{children}</div>
+      </div>
+    </div>
   );
 };
 export default Header;

--- a/src/data/HeaderItems.ts
+++ b/src/data/HeaderItems.ts
@@ -1,0 +1,24 @@
+import { ItemType } from '../types/headerItemType';
+
+export const HeaderItems: ItemType[] = [
+  {
+    title: '活動内容',
+    url: 'ahiahi',
+  },
+  {
+    title: '実績',
+    url: 'url',
+  },
+  {
+    title: 'アクセス',
+    url: 'hogehoge',
+  },
+  {
+    title: 'ブログ',
+    url: 'fugafuga',
+  },
+  {
+    title: 'Q&A',
+    url: 'piyopiyo',
+  },
+];

--- a/src/data/SocialLinks.ts
+++ b/src/data/SocialLinks.ts
@@ -1,0 +1,17 @@
+import { faGithub, faTwitter } from '@fortawesome/free-brands-svg-icons';
+import { socialLinksType } from '../types/socialLinksType';
+
+export const socialLinks: socialLinksType[] = [
+  {
+    name: 'Twitter',
+    url: 'https://twitter.com/kyutech_proken',
+    color: '#1DA1F2',
+    iconClass: faTwitter,
+  },
+  {
+    name: 'GitHub',
+    url: 'https://github.com/kyutech-programming-club',
+    color: '171515',
+    iconClass: faGithub,
+  },
+];

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,8 +1,14 @@
 import { AppProps } from 'next/app';
 import 'tailwindcss/tailwind.css';
 
+import Header from '../components/Header';
+
 function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <Header>
+      <Component {...pageProps} />
+    </Header>
+  );
 }
 
 export default App;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,35 +4,36 @@ import Header from '../components/Header';
 const Home = () => {
   return (
     <div>
-      <Header />
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
-      <p>ahiahi page</p>
+      <Header>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+        <p>ahiahi page</p>
+      </Header>
     </div>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,36 +4,34 @@ import Header from '../components/Header';
 const Home = () => {
   return (
     <div>
-      <Header>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-        <p>ahiahi page</p>
-      </Header>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
+      <p>ahiahi page</p>
     </div>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,4 @@
 import 'tailwindcss/tailwind.css';
-import Header from '../components/Header';
 
 const Home = () => {
   return (

--- a/src/types/headerItemType.ts
+++ b/src/types/headerItemType.ts
@@ -1,0 +1,4 @@
+export interface ItemType {
+  title: string;
+  url: string;
+}

--- a/src/types/socialLinksType.ts
+++ b/src/types/socialLinksType.ts
@@ -1,0 +1,8 @@
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+
+export interface socialLinksType {
+  name: string;
+  url: string;
+  color: string;
+  iconClass: IconDefinition;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,6 +106,39 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fortawesome/fontawesome-common-types@^0.2.35":
+  version "0.2.35"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz#01dd3d054da07a00b764d78748df20daf2b317e9"
+  integrity sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw==
+
+"@fortawesome/fontawesome-svg-core@^1.2.35":
+  version "1.2.35"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz#85aea8c25645fcec88d35f2eb1045c38d3e65cff"
+  integrity sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.35"
+
+"@fortawesome/free-brands-svg-icons@^5.15.3":
+  version "5.15.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.15.3.tgz#bec2821d23b9c667be1d192a6c5bfb2667e588eb"
+  integrity sha512-1hirPcbjj72ZJtFvdnXGPbAbpn3Ox6mH3g5STbANFp3vGSiE5u5ingAKV06mK6ZVqNYxUPlh4DlTnaIvLtF2kw==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.35"
+
+"@fortawesome/free-solid-svg-icons@^5.15.3":
+  version "5.15.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz#52eebe354f60dc77e0bde934ffc5c75ffd04f9d8"
+  integrity sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.35"
+
+"@fortawesome/react-fontawesome@^0.1.14":
+  version "0.1.14"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.14.tgz#bf28875c3935b69ce2dc620e1060b217a47f64ca"
+  integrity sha512-4wqNb0gRLVaBm/h+lGe8UfPPivcbuJ6ecI4hIgW0LjI7kzpYB9FkN0L9apbVzg+lsBdcTf0AlBtODjcSX5mmKA==
+  dependencies:
+    prop-types "^15.7.2"
+
 "@fullhuman/postcss-purgecss@^3.1.3":
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/@fullhuman/postcss-purgecss/-/postcss-purgecss-3.1.3.tgz#47af7b87c9bfb3de4bc94a38f875b928fffdf339"


### PR DESCRIPTION
## やったこと💪 
- ### `components`配下に`header.tsx`を作成した。
  - ファイル内で扱う変数の型を`type`ファイルに切り出し。
  - `Header`の内容を`data`配下に切り出し。
- ### 画面の共通レイアウトとして`header.tsx`を読み込むために`_app.tsx`に`Header`を記述した。
  - headerの画面表示を`sticky`にするために、`Header`を共通レイアウトにする必要があった。
- ###  `font awesome`を使って、TwitterとGitHubのロゴをを`Header`上に貼った。
  - リンクは貼り付け済みです
  
## 要対応✔
- 各目ページの実装はまだなので、あくまでハリボテ`Header`です。クリックによるページ遷移はまだできません。
  - `HeaderItems`に`url`という項目があるので、そこにURLを入力したらページ遷移できるようになります。